### PR TITLE
wailist and internship categories documented and edited

### DIFF
--- a/src/database/migration/1649240451086-internship.ts
+++ b/src/database/migration/1649240451086-internship.ts
@@ -1,0 +1,24 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class internship1649240451086 implements MigrationInterface {
+    name = 'internship1649240451086'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "internship_category" ADD "createdOn" TIMESTAMP NOT NULL DEFAULT now()`);
+        await queryRunner.query(`ALTER TABLE "internship_category" ADD "createdBy" character varying`);
+        await queryRunner.query(`ALTER TABLE "internship_category" ADD "updatedOn" TIMESTAMP`);
+        await queryRunner.query(`ALTER TABLE "internship_category" ADD "updatedBy" character varying`);
+        await queryRunner.query(`ALTER TABLE "internship_category" ADD "deletedOn" TIMESTAMP WITH TIME ZONE`);
+        await queryRunner.query(`ALTER TABLE "internship_category" ADD "deletedBy" character varying`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "internship_category" DROP COLUMN "deletedBy"`);
+        await queryRunner.query(`ALTER TABLE "internship_category" DROP COLUMN "deletedOn"`);
+        await queryRunner.query(`ALTER TABLE "internship_category" DROP COLUMN "updatedBy"`);
+        await queryRunner.query(`ALTER TABLE "internship_category" DROP COLUMN "updatedOn"`);
+        await queryRunner.query(`ALTER TABLE "internship_category" DROP COLUMN "createdBy"`);
+        await queryRunner.query(`ALTER TABLE "internship_category" DROP COLUMN "createdOn"`);
+    }
+
+}

--- a/src/database/migration/1649241020764-waitlistEdit.ts
+++ b/src/database/migration/1649241020764-waitlistEdit.ts
@@ -1,0 +1,24 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class waitlistEdit1649241020764 implements MigrationInterface {
+    name = 'waitlistEdit1649241020764'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "waitlist" ADD "createdOn" TIMESTAMP NOT NULL DEFAULT now()`);
+        await queryRunner.query(`ALTER TABLE "waitlist" ADD "createdBy" character varying`);
+        await queryRunner.query(`ALTER TABLE "waitlist" ADD "updatedOn" TIMESTAMP`);
+        await queryRunner.query(`ALTER TABLE "waitlist" ADD "updatedBy" character varying`);
+        await queryRunner.query(`ALTER TABLE "waitlist" ADD "deletedOn" TIMESTAMP WITH TIME ZONE`);
+        await queryRunner.query(`ALTER TABLE "waitlist" ADD "deletedBy" character varying`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "waitlist" DROP COLUMN "deletedBy"`);
+        await queryRunner.query(`ALTER TABLE "waitlist" DROP COLUMN "deletedOn"`);
+        await queryRunner.query(`ALTER TABLE "waitlist" DROP COLUMN "updatedBy"`);
+        await queryRunner.query(`ALTER TABLE "waitlist" DROP COLUMN "updatedOn"`);
+        await queryRunner.query(`ALTER TABLE "waitlist" DROP COLUMN "createdBy"`);
+        await queryRunner.query(`ALTER TABLE "waitlist" DROP COLUMN "createdOn"`);
+    }
+
+}

--- a/src/entities/intershipCategory.entity.ts
+++ b/src/entities/intershipCategory.entity.ts
@@ -1,16 +1,16 @@
+import { SharedEntity } from '../common/model/sharedEntity';
 import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
 import { Waitlist } from '../entities/waitlist.entity';
+import { ApiProperty } from '@nestjs/swagger';
 
 @Entity()
-export class InternshipCategory {
-  @PrimaryGeneratedColumn('uuid')
-  id: string;
-
+export class InternshipCategory extends SharedEntity{
+  @ApiProperty()
   @Column({
     unique: true,
   })
   categoryName: string;
-
+  
   @OneToMany(() => Waitlist, (wait) => wait.category)
   waiting: Waitlist[];
   // this maps the internship category with the array of waitlist under this currrent category

--- a/src/entities/waitlist.entity.ts
+++ b/src/entities/waitlist.entity.ts
@@ -1,16 +1,15 @@
-import { Entity, Column, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
+import { SharedEntity } from '../common/model/sharedEntity';
+import { Entity, Column, ManyToOne,  } from 'typeorm';
 import { InternshipCategory } from '../entities/intershipCategory.entity';
+import { ApiProperty } from '@nestjs/swagger';
 
 @Entity()
-export class Waitlist {
-  @PrimaryGeneratedColumn('uuid')
-  id: string;
-
-  @Column({
-    unique: true,
-  })
+export class Waitlist extends SharedEntity {
+ 
+  @ApiProperty()
+  @Column({unique: true,})
   email: string;
-
+  
   @ManyToOne(() => InternshipCategory, (internCat) => internCat.categoryName)
   category: InternshipCategory;
   // this maps the waitlist entry with the internship category selected during adding the entry into the waitlist array

--- a/src/intershipCategories/internshipCategories.controllers.ts
+++ b/src/intershipCategories/internshipCategories.controllers.ts
@@ -11,13 +11,18 @@ import { InternshipCategory } from '../entities/intershipCategory.entity';
 import { InternshipCategoryDto } from '../intershipCategories/dto/internshipCategory.dto';
 import { Ok } from 'src/common/helpers/response/ResponseType';
 import { ZuAppResponse } from 'src/common/helpers/response/Response';
+import { ApiTags, ApiOkResponse } from '@nestjs/swagger';
 
-@Controller('/intcat')
+
+@ApiTags('Internship-Category')
+@Controller('/internship-category')
 export class InternshipCategoryContoller {
   constructor(
     private readonly internshipcategoryService: InternshipCategoryService,
   ) {}
 
+
+  @ApiOkResponse({ type: InternshipCategory, isArray: true })
   @Get()
   async allCategories(): Promise<Ok<InternshipCategory[]>> {
     const internshipCategories = await this.internshipcategoryService.findAll();
@@ -31,16 +36,18 @@ export class InternshipCategoryContoller {
     return ZuAppResponse.Ok(newCategory, "List Of all in internship categories", "201");
   }
 
+  @ApiOkResponse({ type: InternshipCategory })
   @Get('/:id')
   async showOneCategorybyId(@Param('id', new ParseUUIDPipe()) id: string) {
     const category = await this.internshipcategoryService.findOneCategoryById(id);
     return ZuAppResponse.Ok(category, "Category found", "200");
   }
 
-  @Get('name')
+  @Post('/category-name')
   async showOneCategoryByName(
-    @Body() internshipCategory: InternshipCategoryDto,
+    @Body() internshipCategory: InternshipCategoryDto ,
   ) {
+    console.log(internshipCategory)
     const category = await this.internshipcategoryService.findOneByCatergoryName(
       internshipCategory.categoryName,
     );

--- a/src/intershipCategories/internshipCategories.controllers.ts
+++ b/src/intershipCategories/internshipCategories.controllers.ts
@@ -47,7 +47,6 @@ export class InternshipCategoryContoller {
   async showOneCategoryByName(
     @Body() internshipCategory: InternshipCategoryDto ,
   ) {
-    console.log(internshipCategory)
     const category = await this.internshipcategoryService.findOneByCatergoryName(
       internshipCategory.categoryName,
     );

--- a/src/intershipCategories/internshipCategory.service.ts
+++ b/src/intershipCategories/internshipCategory.service.ts
@@ -5,8 +5,6 @@ import {
 } from '@nestjs/common';
 import { InternshipCategory } from '../entities/intershipCategory.entity';
 import { InternshipCategoryDto } from './dto/internshipCategory.dto';
-import { Repository } from 'typeorm';
-import { InjectRepository } from '@nestjs/typeorm';
 import { ZuAppResponse } from 'src/common/helpers/response';
 import { InternshipCategoryRepository } from 'src/database/repository/internship-category.repository';
 
@@ -25,7 +23,7 @@ export class InternshipCategoryService {
     internshipCategory: InternshipCategoryDto,
   ): Promise<InternshipCategory> {
     //check if the category already exists
-    const existingCategory = await this.internshipCategoryRepository.find({
+    const existingCategory = await this.internshipCategoryRepository.findOne({
       where: { categoryName: internshipCategory.categoryName },
     });
     if (existingCategory) {
@@ -42,11 +40,11 @@ export class InternshipCategoryService {
   }
   // this add a new category into the internship category list
 
-  async findOneByCatergoryName(
+   async findOneByCatergoryName(
     categoryName: string,
   ): Promise<InternshipCategory> {
     const category = await this.internshipCategoryRepository.findOne({
-      where: { categoryName },
+      where: { categoryName : categoryName },
       relations: ['waiting'],
       // relations options displays the waitlist entry under the fetched category
     });
@@ -60,6 +58,8 @@ export class InternshipCategoryService {
     }
     return category;
   }
+
+
   // this fetches an internship category
 
   async findOneCategoryById(id: string): Promise<InternshipCategory> {

--- a/src/waitlist/dto/waitlist.dto.ts
+++ b/src/waitlist/dto/waitlist.dto.ts
@@ -2,7 +2,7 @@ import { InternshipCategory } from '../../entities/intershipCategory.entity';
 import { IsEmail } from 'class-validator';
 
 export class WaitlistDto {
-  id?: string;
+  // id?: string;
 
   @IsEmail()
   email: string;

--- a/src/waitlist/dto/waitlist.dto.ts
+++ b/src/waitlist/dto/waitlist.dto.ts
@@ -1,7 +1,11 @@
 import { InternshipCategory } from '../../entities/intershipCategory.entity';
+import { IsEmail } from 'class-validator';
 
 export class WaitlistDto {
   id?: string;
+
+  @IsEmail()
   email: string;
+  
   category: InternshipCategory;
 }

--- a/src/waitlist/waitlist.controllers.ts
+++ b/src/waitlist/waitlist.controllers.ts
@@ -2,20 +2,22 @@ import {
   Body,
   Controller,
   Get,
-  Param,
   Post,
-  ParseUUIDPipe,
 } from '@nestjs/common';
 import { WaitlistsService } from '../waitlist/waitlist.service';
 import { WaitlistDto } from '../waitlist/dto/waitlist.dto';
 import { Waitlist } from '../entities/waitlist.entity';
 import { ZuAppResponse } from 'src/common/helpers/response/Response';
 import { Ok } from 'src/common/helpers/response/ResponseType';
+import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 
+
+@ApiTags('Waitlist')
 @Controller('waitlist')
 export class WaitlistController {
   constructor(private readonly waitlistService: WaitlistsService) {}
 
+  @ApiOkResponse({type: Waitlist, isArray: true})
   @Get()
   async showWaitlist(): Promise<Ok<Waitlist[]>> {
     const waitingList = await this.waitlistService.findAll();

--- a/src/waitlist/waitlist.service.ts
+++ b/src/waitlist/waitlist.service.ts
@@ -1,7 +1,5 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { Waitlist } from '../entities/waitlist.entity';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
 import { WaitlistDto } from './dto/waitlist.dto';
 import { ZuAppResponse } from 'src/common/helpers/response';
 import { WaitlistRepository } from 'src/database/repository/waitlist.repository';
@@ -22,7 +20,7 @@ export class WaitlistsService {
 
   async addToWaitlist(waitlist: WaitlistDto): Promise<Waitlist> {
     //check if email already exists
-    const existingEmail = await this.waitlistRepository.find({ where: { email:waitlist.email}})
+    const existingEmail = await this.waitlistRepository.findOne({ where: { email:waitlist.email}})
     if(existingEmail){
       throw new BadRequestException(
         ZuAppResponse.BadRequest( " Duplicate Values", "This email has already been added to the waitlist")


### PR DESCRIPTION
1. waitlist and internship category entities extended to shared entity
2. new migrations generated and ran for both entities
3. Api tags added to both controllers for the swagger UI